### PR TITLE
BE- Bugfix: Email is unique identifier

### DIFF
--- a/src/main/java/org/launchcode/books2borrow/models/Customer.java
+++ b/src/main/java/org/launchcode/books2borrow/models/Customer.java
@@ -26,7 +26,7 @@ public class Customer {
 
     @Email(message = "Invalid email. Try again")
     @NotBlank(message = "Email is required")
-    @Column(unique=true)
+    @Column(unique = true)
     private String email;
 
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)


### PR DESCRIPTION
Corrected Hibernate annotation to correctly build the customer table to make email a unique field. Will now throw hibernate error if trying to add duplicate customer with the same email.

SORRY....NEED TO DROP CUSTOMER TABLE AGAIN SO IT WILL BUILD CORRECTLY 😅😒😭